### PR TITLE
Remove Hardcoded W&B API

### DIFF
--- a/utils/logger_tools.py
+++ b/utils/logger_tools.py
@@ -49,7 +49,6 @@ def set_args_and_logger(args, rank):
     if not os.path.exists(args_name_dir): os.makedirs(args_name_dir)
     args_name = args_name_dir + "/" + args.name +".yaml"
     
-    os.environ["WANDB_API_KEY"] = '91fe156c60374c4eb00dd6a990017b0371e32737'
     os.environ["WANDB_MODE"] = "offline"
     
     if rank == 0:


### PR DESCRIPTION
If you are using a static machine (local computer, VM, etc.) the W&B login is required to be authenticated with API key only once. To prevent anyone else from accessing your W&B profile, I am making this PR to remove it. Hope you find it helpful.