### PR TITLE
 Accelerate Video Generation, Reducing the Time to Generate a 62s Video from 1000s to About 25s

### DIFF
--- a/scripts/EMAGE_2024/readme.md
+++ b/scripts/EMAGE_2024/readme.md
@@ -14,8 +14,8 @@ We Recommend a python version `==3.8` and cuda version `==12.2`. Then build envi
 git clone https://github.com/PantoMatrix/PantoMatrix.git
 conda create -n emagepy38 python==3.8
 conda activate emagepy38
-# Prerequisite for rendering
-conda install -c conda-forge libstdcxx-ng
+# Install ffmpeg for media processing and libstdcxx-ng for rendering
+conda install -c conda-forge libstdcxx-ng ffmpeg
 # Install with pip:
 pip install -r ./scripts/EMAGE_2024/requirements.txt
 pip install 'git+https://github.com/facebookresearch/pytorch3d.git@stable'

--- a/scripts/EMAGE_2024/utils/config.py
+++ b/scripts/EMAGE_2024/utils/config.py
@@ -2,6 +2,7 @@ import configargparse
 import time
 import json
 import yaml
+import os
 
 
 def str2bool(v):
@@ -246,6 +247,13 @@ def parse_args():
     parser.add("--ddp", default=False, type=str2bool)
     parser.add("--sparse", default=1, type=int)
     #parser.add("--world_size")
+    parser.add("--render_video_fps", default=30, type=int)
+    parser.add("--render_video_width", default=1920, type=int)
+    parser.add("--render_video_height", default=720, type=int)
+    cpu_cores = os.cpu_count() if os.cpu_count() is not None else 1
+    default_concurrent = max(1, cpu_cores // 2)
+    parser.add("--render_concurrent_num", default=default_concurrent, type=int)
+    parser.add("--render_tmp_img_filetype", default="bmp", type=str)
     
     # logging
     parser.add("--log_period", default=10, type=int)

--- a/scripts/EMAGE_2024/utils/fast_render.py
+++ b/scripts/EMAGE_2024/utils/fast_render.py
@@ -1,0 +1,153 @@
+import os
+import time
+import numpy as np
+import pyrender
+import trimesh
+import queue
+import imageio
+import threading
+import multiprocessing
+import utils.media
+import glob
+
+def deg_to_rad(degrees):
+    return degrees * np.pi / 180
+
+def create_pose_camera(angle_deg):
+    angle_rad = deg_to_rad(angle_deg)
+    return np.array([
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, np.cos(angle_rad), -np.sin(angle_rad), 1.0],
+        [0.0, np.sin(angle_rad), np.cos(angle_rad), 5.0],
+        [0.0, 0.0, 0.0, 1.0]
+    ])
+
+def create_pose_light(angle_deg):
+    angle_rad = deg_to_rad(angle_deg)
+    return np.array([
+        [1.0, 0.0, 0.0, 0.0],
+        [0.0, np.cos(angle_rad), -np.sin(angle_rad), 0.0],
+        [0.0, np.sin(angle_rad), np.cos(angle_rad), 3.0],
+        [0.0, 0.0, 0.0, 1.0]
+    ])
+
+def create_scene_with_mesh(vertices, faces, uniform_color, pose_camera, pose_light):
+    trimesh_mesh = trimesh.Trimesh(vertices=vertices, faces=faces, vertex_colors=uniform_color)
+    mesh = pyrender.Mesh.from_trimesh(trimesh_mesh, smooth=True)
+    scene = pyrender.Scene()
+    scene.add(mesh)
+    camera = pyrender.OrthographicCamera(xmag=1.0, ymag=1.0)
+    scene.add(camera, pose=pose_camera)
+    light = pyrender.DirectionalLight(color=[1.0, 1.0, 1.0], intensity=4.0)
+    scene.add(light, pose=pose_light)
+    return scene
+
+def do_render_one_frame(renderer, frame_idx, vertices, vertices1, faces):
+    if frame_idx % 100 == 0:
+        print('processed', frame_idx, 'frames')
+
+    uniform_color = [220, 220, 220, 255]
+    pose_camera = create_pose_camera(angle_deg=-2)
+    pose_light = create_pose_light(angle_deg=-30)
+
+    figs = []
+    for vtx in [vertices, vertices1]:
+        scene = create_scene_with_mesh(vtx, faces, uniform_color, pose_camera, pose_light)
+        fig, _ = renderer.render(scene)
+        figs.append(fig)
+  
+    return figs[0], figs[1]
+
+def write_images_from_queue(fig_queue, output_dir, img_filetype):
+    while True:
+        e = fig_queue.get()
+        if e is None:
+            break
+        fid, fig1, fig2 = e
+        filename = os.path.join(output_dir, f"frame_{fid}.{img_filetype}")
+        merged_fig = np.hstack((fig1, fig2))
+        try:
+            imageio.imwrite(filename, merged_fig)
+        except Exception as ex:
+            print(f"Error writing image {filename}: {ex}")
+            raise ex
+    
+def render_frames_and_enqueue(fids, frame_vertex_pairs, faces, render_width, render_height, fig_queue):
+    fig_resolution = (render_width // 2, render_height)
+    renderer = pyrender.OffscreenRenderer(*fig_resolution)
+
+    for idx, fid in enumerate(fids):
+        fig1, fig2 = do_render_one_frame(renderer, fid, frame_vertex_pairs[idx][0], frame_vertex_pairs[idx][1], faces)
+        fig_queue.put((fid, fig1, fig2))
+    
+    renderer.delete()
+
+def sub_process_process_frame(subprocess_index, render_video_width, render_video_height, render_tmp_img_filetype, fids, frame_vertex_pairs, faces, output_dir):
+    begin_ts = time.time()
+    print(f"subprocess_index={subprocess_index} begin_ts={begin_ts}")
+
+    fig_queue = queue.Queue()
+    render_frames_and_enqueue(fids, frame_vertex_pairs, faces, render_video_width, render_video_height, fig_queue)
+    fig_queue.put(None)
+    render_end_ts = time.time()
+
+    image_writer_thread = threading.Thread(target=write_images_from_queue, args=(fig_queue, output_dir, render_tmp_img_filetype))
+    image_writer_thread.start()
+    image_writer_thread.join()
+
+    write_end_ts = time.time()
+    print(
+        f"subprocess_index={subprocess_index} "
+        f"render={render_end_ts - begin_ts:.2f} "
+        f"all={write_end_ts - begin_ts:.2f} "
+        f"begin_ts={begin_ts:.2f} "
+        f"render_end_ts={render_end_ts:.2f} "
+        f"write_end_ts={write_end_ts:.2f}"
+    )
+
+def distribute_frames(frames, render_video_fps, render_concurent_nums, vertices_all, vertices1_all):
+    sample_interval = max(1, int(30 // render_video_fps))
+    subproc_frame_ids = [[] for _ in range(render_concurent_nums)]
+    subproc_vertices = [[] for _ in range(render_concurent_nums)]
+    sampled_frame_id = 0
+
+    for i in range(frames):
+        if i % sample_interval != 0:
+            continue
+        subprocess_index = sampled_frame_id % render_concurent_nums
+        subproc_frame_ids[subprocess_index].append(sampled_frame_id)
+        subproc_vertices[subprocess_index].append((vertices_all[i], vertices1_all[i]))
+        sampled_frame_id += 1
+
+    return subproc_frame_ids, subproc_vertices
+
+def generate_silent_videos(render_video_fps, 
+                           render_video_width,
+                           render_video_height,
+                           render_concurent_nums,
+                           render_tmp_img_filetype,
+                           frames, 
+                           vertices_all,
+                           vertices1_all,
+                           faces,
+                           output_dir):
+
+    subproc_frame_ids, subproc_vertices = distribute_frames(frames, render_video_fps, render_concurent_nums, vertices_all, vertices1_all)
+
+    print(f"generate_silent_videos concurrentNum={render_concurent_nums} time={time.time()}")
+    with multiprocessing.Pool(render_concurent_nums) as pool:
+        pool.starmap(
+            sub_process_process_frame, 
+            [
+                (subprocess_index,  render_video_width, render_video_height, render_tmp_img_filetype, subproc_frame_ids[subprocess_index],  subproc_vertices[subprocess_index], faces, output_dir) 
+                    for subprocess_index in range(render_concurent_nums)
+            ]
+        )
+
+    output_file = os.path.join(output_dir, "silence_video.mp4")
+    utils.media.convert_img_to_mp4(os.path.join(output_dir, f"frame_%d.{render_tmp_img_filetype}"), output_file, render_video_fps)
+    filenames = glob.glob(os.path.join(output_dir, f"*.{render_tmp_img_filetype}"))
+    for filename in filenames:
+        os.remove(filename)
+
+    return output_file

--- a/scripts/EMAGE_2024/utils/media.py
+++ b/scripts/EMAGE_2024/utils/media.py
@@ -1,0 +1,39 @@
+import numpy as np
+import subprocess
+
+def add_audio_to_video(silent_video_path, audio_path, output_video_path):
+    command = [
+        'ffmpeg',
+        '-y',
+        '-i', silent_video_path,
+        '-i', audio_path,
+        '-map', '0:v',
+        '-map', '1:a',
+        '-c:v', 'copy',
+        '-shortest',
+        output_video_path
+    ]
+    
+    try:
+        subprocess.run(command, check=True)
+        print(f"Video with audio generated successfully: {output_video_path}")
+    except subprocess.CalledProcessError as e:
+        print(f"Error occurred: {e}")
+
+
+def convert_img_to_mp4(input_pattern, output_file, framerate=30):
+    command = [
+        'ffmpeg.exe',
+        '-framerate', str(framerate),
+        '-i', input_pattern,
+        '-c:v', 'libx264',
+        '-pix_fmt', 'yuv420p',
+        output_file,
+        '-y' 
+    ]
+    
+    try:
+        subprocess.run(command, check=True)
+        print(f"Video conversion successful. Output file: {output_file}")
+    except subprocess.CalledProcessError as e:
+        print(f"Error during video conversion: {e}")

--- a/scripts/EMAGE_2024/utils/other_tools.py
+++ b/scripts/EMAGE_2024/utils/other_tools.py
@@ -15,6 +15,8 @@ import hashlib
 from scipy.spatial.transform import Rotation as R
 from scipy.spatial.transform import Slerp
 import cv2
+import utils.media
+import utils.fast_render
 
 def write_wav_names_to_csv(folder_path, csv_path):
     """
@@ -637,9 +639,10 @@ def render_one_sequence(
     # if not use_matplotlib:
     #    import trimesh 
        #import pyrender
-    from pyvirtualdisplay import Display
-    display = Display(visible=0, size=(1000, 1000))
-    display.start()
+    #!!! I only have Windows, the following lines of comments are feasible, but have not been tested on other platforms.
+    #from pyvirtualdisplay import Display
+    #display = Display(visible=0, size=(500, 500))
+    #display.start()
     faces = np.load(f"{model_folder}/smplx/SMPLX_NEUTRAL_2020.npz", allow_pickle=True)["f"]     
     seconds = 1
     #data_npz["jaw_pose"].shape[0]
@@ -671,124 +674,23 @@ def render_one_sequence(
         seconds = 1
     else:
         seconds = vertices_all.shape[0]//30
-    # camera_settings = None    
-    time_s = time.time()
-    generate_images(int(seconds*30), vertices_all, vertices1_all, faces, output_dir, filenames)
-    filenames = [f"{output_dir}frame_{i}.png" for i in range(int(seconds*30))]  
-    # print(time.time()-time_s)
-    # for i in tqdm(range(seconds*30)):
-    #     vertices = vertices_all[i]
-    #     vertices1 = vertices1_all[i]
-    #     filename = f"{output_dir}frame_{i}.png"
-    #     filenames.append(filename)
-    #     #time_s = time.time()
-    #     #print(vertices.shape)
-    #     if use_matplotlib:
-    #         fig = plt.figure(figsize=(20, 10))
-    #         ax = fig.add_subplot(121, projection="3d")
-    #         fig.subplots_adjust(left=0, right=1, bottom=0, top=1)
-    #         #ax.view_init(elev=0, azim=90)
-    #         x = vertices[:, 0]
-    #         y = vertices[:, 1]
-    #         z = vertices[:, 2]
-    #         ax.scatter(x, y, z, s=0.5)
-    #         ax.set_xlim([-1.0, 1.0])
-    #         ax.set_ylim([-0.5, 1.5])#heigth
-    #         ax.set_zlim([-0, 2])#depth
-    #         ax.set_box_aspect((1,1,1))
-    #     else:
-    #         mesh = trimesh.Trimesh(vertices, faces)
-    #         if i == 0:
-    #             scene = mesh.scene()
-    #             camera_params = {
-    #                 'fov': scene.camera.fov,
-    #                 'resolution': scene.camera.resolution,
-    #                 'focal': scene.camera.focal,
-    #                 'z_near': scene.camera.z_near,
-    #                 "z_far": scene.camera.z_far,
-    #                 'transform': scene.graph[scene.camera.name][0]
-    #             }
-    #         else: 
-    #             scene = mesh.scene()
-    #             scene.camera.fov = camera_params['fov']
-    #             scene.camera.resolution = camera_params['resolution']
-    #             scene.camera.z_near = camera_params['z_near']
-    #             scene.camera.z_far = camera_params['z_far']
-    #             scene.graph[scene.camera.name] = camera_params['transform']
-    #         fig, ax =plt.subplots(1,2, figsize=(16, 6))
-    #         image = scene.save_image(resolution=[640, 480], visible=False)
-    #         #print((time.time()-time_s))   
-    #         im0 = ax[0].imshow(image_from_bytes(image))
-    #         ax[0].axis('off')
-
-    #     # beta1 = torch.from_numpy(gt_np_body["betas"]).to(torch.float32).unsqueeze(0)
-    #     # expression1 = torch.from_numpy(gt_np_body["expressions"][i]).to(torch.float32).unsqueeze(0)
-    #     # jaw_pose1 = torch.from_numpy(gt_np_body["poses"][i][66:69]).to(torch.float32).unsqueeze(0)
-    #     # pose1 = torch.from_numpy(gt_np_body["poses"][i]).to(torch.float32).unsqueeze(0)
-    #     # transl1 = torch.from_numpy(gt_np_body["trans"][i]).to(torch.float32).unsqueeze(0)
-    #     # #print(beta.shape, expression.shape, jaw_pose.shape, pose.shape, transl.shape)global_orient=pose[0:1,:3],
-    #     # output1 = model(betas=beta1, transl=transl1, expression=expression1, jaw_pose=jaw_pose1, global_orient=pose1[0:1,:3], body_pose=pose1[0:1,3:21*3+3], left_hand_pose=pose1[0:1,25*3:40*3], right_hand_pose=pose1[0:1,40*3:55*3], return_verts=True)
-    #     # vertices1 = output1["vertices"].cpu().detach().numpy()[0]
-        
-    #     if use_matplotlib:
-    #         ax2 = fig.add_subplot(122, projection="3d")
-    #         ax2.set_box_aspect((1,1,1))
-    #         fig.subplots_adjust(left=0, right=1, bottom=0, top=1)
-    #         #ax2.view_init(elev=0, azim=90)
-    #         x1 = vertices1[:, 0]
-    #         y1 = vertices1[:, 1]
-    #         z1 = vertices1[:, 2]
-    #         ax2.scatter(x1, y1, z1, s=0.5)
-    #         ax2.set_xlim([-1.0, 1.0])
-    #         ax2.set_ylim([-0.5, 1.5])#heigth
-    #         ax2.set_zlim([-0, 2])
-    #         plt.savefig(filename, bbox_inches='tight')
-    #         plt.close(fig)
-    #     else:
-    #         mesh1 = trimesh.Trimesh(vertices1, faces)
-    #         if i == 0:
-    #             scene1 = mesh1.scene()
-    #             camera_params1 = {
-    #                 'fov': scene1.camera.fov,
-    #                 'resolution': scene1.camera.resolution,
-    #                 'focal': scene1.camera.focal,
-    #                 'z_near': scene1.camera.z_near,
-    #                 "z_far": scene1.camera.z_far,
-    #                 'transform': scene1.graph[scene1.camera.name][0]
-    #             }
-    #         else: 
-    #             scene1 = mesh1.scene()
-    #             scene1.camera.fov = camera_params1['fov']
-    #             scene1.camera.resolution = camera_params1['resolution']
-    #             scene1.camera.z_near = camera_params1['z_near']
-    #             scene1.camera.z_far = camera_params1['z_far']
-    #             scene1.graph[scene1.camera.name] = camera_params1['transform']
-    #         image1 = scene1.save_image(resolution=[640, 480], visible=False)
-    #         im1 = ax[1].imshow(image_from_bytes(image1))
-    #         ax[1].axis('off')
-    #         plt.savefig(filename, bbox_inches='tight')
-    #         plt.close(fig)
-
-    display.stop()
-    # print(filenames)
-    images = [imageio.imread(filename) for filename in filenames]
-    imageio.mimsave(f"{output_dir}raw_{res_npz_path.split('/')[-1][:-4]}.mp4", images, fps=30)
-    for filename in filenames:
-        os.remove(filename)
-        
-    video = mp.VideoFileClip(f"{output_dir}raw_{res_npz_path.split('/')[-1][:-4]}.mp4")
-    # audio, sr = librosa.load(audio_path)
-    # audio = audio[:seconds*sr]
-    # print(audio.shape, seconds, sr)
-    # import soundfile as sf
-    # sf.write(f"{output_dir}{res_npz_path.split('/')[-1][:-4]}.wav", audio, 16000, 'PCM_24')
-    # audio_tmp = librosa.output.write_wav(f"{output_dir}{res_npz_path.split('/')[-1][:-4]}.wav", audio, sr=16000)
-    audio = mp.AudioFileClip(audio_path)
-    if audio.duration > video.duration:
-        audio = audio.subclip(0, video.duration)
-    final_clip = video.set_audio(audio)
-    final_clip.write_videofile(f"{output_dir}{res_npz_path.split('/')[-1][4:-4]}.mp4")
-    os.remove(f"{output_dir}raw_{res_npz_path.split('/')[-1][:-4]}.mp4")
+  
+    silent_video_file_path = utils.fast_render.generate_silent_videos(args.render_video_fps, 
+                                                                args.render_video_width,
+                                                                args.render_video_height,
+                                                                args.render_concurrent_num,
+                                                                args.render_tmp_img_filetype,
+                                                                int(seconds*args.render_video_fps), 
+                                                                vertices_all,
+                                                                vertices1_all,
+                                                                faces,
+                                                                output_dir)
+    
+    #final_clip = f"{output_dir}{res_npz_path.split('/')[-1][4:-4]}.mp4"
+    base_filename_without_ext = os.path.splitext(os.path.basename(res_npz_path))[0]
+    final_clip = os.path.join(output_dir, f"{base_filename_without_ext}.mp4")
+    utils.media.add_audio_to_video(silent_video_file_path, audio_path, final_clip)
+    os.remove(silent_video_file_path)
 
 def print_exp_info(args):
     logger.info(pprint.pformat(vars(args)))

--- a/scripts/EMAGE_2024/utils/other_tools_hf.py
+++ b/scripts/EMAGE_2024/utils/other_tools_hf.py
@@ -15,6 +15,8 @@ import hashlib
 from scipy.spatial.transform import Rotation as R
 from scipy.spatial.transform import Slerp
 import cv2
+import utils.media
+import utils.fast_render
 
 def write_wav_names_to_csv(folder_path, csv_path):
     """
@@ -633,7 +635,6 @@ def render_one_sequence(
     gt_np_body = np.load(gt_npz_path, allow_pickle=True)
     
     if not os.path.exists(output_dir): os.makedirs(output_dir)
-    filenames = []
     # if not use_matplotlib:
     #    import trimesh 
        #import pyrender
@@ -672,125 +673,21 @@ def render_one_sequence(
         seconds = 1
     else:
         seconds = vertices_all.shape[0]//30
-    # camera_settings = None    
-    time_s = time.time()
-    generate_images(int(seconds*10), vertices_all, vertices1_all, faces, output_dir, filenames)
-    filenames = ["{}frame_{}.png".format(output_dir, i*3) for i in range(int(seconds*10))]  
-    # print(time.time()-time_s)
-    # for i in tqdm(range(seconds*10)):
-    #     vertices = vertices_all[i]
-    #     vertices1 = vertices1_all[i]
-    #     filename = f"{output_dir}frame_{i}.png"
-    #     filenames.append(filename)
-    #     #time_s = time.time()
-    #     #print(vertices.shape)
-    #     if use_matplotlib:
-    #         fig = plt.figure(figsize=(20, 10))
-    #         ax = fig.add_subplot(121, projection="3d")
-    #         fig.subplots_adjust(left=0, right=1, bottom=0, top=1)
-    #         #ax.view_init(elev=0, azim=90)
-    #         x = vertices[:, 0]
-    #         y = vertices[:, 1]
-    #         z = vertices[:, 2]
-    #         ax.scatter(x, y, z, s=0.5)
-    #         ax.set_xlim([-1.0, 1.0])
-    #         ax.set_ylim([-0.5, 1.5])#heigth
-    #         ax.set_zlim([-0, 2])#depth
-    #         ax.set_box_aspect((1,1,1))
-    #     else:
-    #         mesh = trimesh.Trimesh(vertices, faces)
-    #         if i == 0:
-    #             scene = mesh.scene()
-    #             camera_params = {
-    #                 'fov': scene.camera.fov,
-    #                 'resolution': scene.camera.resolution,
-    #                 'focal': scene.camera.focal,
-    #                 'z_near': scene.camera.z_near,
-    #                 "z_far": scene.camera.z_far,
-    #                 'transform': scene.graph[scene.camera.name][0]
-    #             }
-    #         else: 
-    #             scene = mesh.scene()
-    #             scene.camera.fov = camera_params['fov']
-    #             scene.camera.resolution = camera_params['resolution']
-    #             scene.camera.z_near = camera_params['z_near']
-    #             scene.camera.z_far = camera_params['z_far']
-    #             scene.graph[scene.camera.name] = camera_params['transform']
-    #         fig, ax =plt.subplots(1,2, figsize=(16, 6))
-    #         image = scene.save_image(resolution=[640, 480], visible=False)
-    #         #print((time.time()-time_s))   
-    #         im0 = ax[0].imshow(image_from_bytes(image))
-    #         ax[0].axis('off')
-
-    #     # beta1 = torch.from_numpy(gt_np_body["betas"]).to(torch.float32).unsqueeze(0)
-    #     # expression1 = torch.from_numpy(gt_np_body["expressions"][i]).to(torch.float32).unsqueeze(0)
-    #     # jaw_pose1 = torch.from_numpy(gt_np_body["poses"][i][66:69]).to(torch.float32).unsqueeze(0)
-    #     # pose1 = torch.from_numpy(gt_np_body["poses"][i]).to(torch.float32).unsqueeze(0)
-    #     # transl1 = torch.from_numpy(gt_np_body["trans"][i]).to(torch.float32).unsqueeze(0)
-    #     # #print(beta.shape, expression.shape, jaw_pose.shape, pose.shape, transl.shape)global_orient=pose[0:1,:3],
-    #     # output1 = model(betas=beta1, transl=transl1, expression=expression1, jaw_pose=jaw_pose1, global_orient=pose1[0:1,:3], body_pose=pose1[0:1,3:21*3+3], left_hand_pose=pose1[0:1,25*3:40*3], right_hand_pose=pose1[0:1,40*3:55*3], return_verts=True)
-    #     # vertices1 = output1["vertices"].cpu().detach().numpy()[0]
-        
-    #     if use_matplotlib:
-    #         ax2 = fig.add_subplot(122, projection="3d")
-    #         ax2.set_box_aspect((1,1,1))
-    #         fig.subplots_adjust(left=0, right=1, bottom=0, top=1)
-    #         #ax2.view_init(elev=0, azim=90)
-    #         x1 = vertices1[:, 0]
-    #         y1 = vertices1[:, 1]
-    #         z1 = vertices1[:, 2]
-    #         ax2.scatter(x1, y1, z1, s=0.5)
-    #         ax2.set_xlim([-1.0, 1.0])
-    #         ax2.set_ylim([-0.5, 1.5])#heigth
-    #         ax2.set_zlim([-0, 2])
-    #         plt.savefig(filename, bbox_inches='tight')
-    #         plt.close(fig)
-    #     else:
-    #         mesh1 = trimesh.Trimesh(vertices1, faces)
-    #         if i == 0:
-    #             scene1 = mesh1.scene()
-    #             camera_params1 = {
-    #                 'fov': scene1.camera.fov,
-    #                 'resolution': scene1.camera.resolution,
-    #                 'focal': scene1.camera.focal,
-    #                 'z_near': scene1.camera.z_near,
-    #                 "z_far": scene1.camera.z_far,
-    #                 'transform': scene1.graph[scene1.camera.name][0]
-    #             }
-    #         else: 
-    #             scene1 = mesh1.scene()
-    #             scene1.camera.fov = camera_params1['fov']
-    #             scene1.camera.resolution = camera_params1['resolution']
-    #             scene1.camera.z_near = camera_params1['z_near']
-    #             scene1.camera.z_far = camera_params1['z_far']
-    #             scene1.graph[scene1.camera.name] = camera_params1['transform']
-    #         image1 = scene1.save_image(resolution=[640, 480], visible=False)
-    #         im1 = ax[1].imshow(image_from_bytes(image1))
-    #         ax[1].axis('off')
-    #         plt.savefig(filename, bbox_inches='tight')
-    #         plt.close(fig)
-
-    #display.stop()
-    #'''
-    # print(filenames)
-    images = [imageio.imread(filename) for filename in filenames]
-    imageio.mimsave(f"{output_dir}raw_{res_npz_path.split('/')[-1][:-4]}.mp4", images, fps=10)
-    for filename in filenames:
-        os.remove(filename)
-        
-    video = mp.VideoFileClip(f"{output_dir}raw_{res_npz_path.split('/')[-1][:-4]}.mp4")
-    # audio, sr = librosa.load(audio_path)
-    # audio = audio[:seconds*sr]
-    # print(audio.shape, seconds, sr)
-    # import soundfile as sf
-    # sf.write(f"{output_dir}{res_npz_path.split('/')[-1][:-4]}.wav", audio, 16000, 'PCM_24')
-    # audio_tmp = librosa.output.write_wav(f"{output_dir}{res_npz_path.split('/')[-1][:-4]}.wav", audio, sr=16000)
-    audio = mp.AudioFileClip(audio_path)
-    if audio.duration > video.duration:
-        audio = audio.subclip(0, video.duration)
-    final_clip = video.set_audio(audio)
-    final_clip.write_videofile(f"{output_dir}{res_npz_path.split('/')[-1][4:-4]}.mp4")
-    os.remove(f"{output_dir}raw_{res_npz_path.split('/')[-1][:-4]}.mp4")
+    silent_video_file_path = utils.fast_render.generate_silent_videos(args.render_video_fps,
+                                                                args.render_video_width,
+                                                                args.render_video_height,
+                                                                args.render_concurrent_num,
+                                                                args.render_tmp_img_filetype,
+                                                                int(seconds*args.render_video_fps), 
+                                                                vertices_all,
+                                                                vertices1_all,
+                                                                faces,
+                                                                output_dir)
+    base_filename_without_ext = os.path.splitext(os.path.basename(res_npz_path))[0]
+    final_clip = os.path.join(output_dir, f"{base_filename_without_ext}.mp4")
+    utils.media.add_audio_to_video(silent_video_file_path, audio_path, final_clip)
+    os.remove(silent_video_file_path)
+    return final_clip
 
 def print_exp_info(args):
     logger.info(pprint.pformat(vars(args)))


### PR DESCRIPTION
Main Optimization Points:
- Avoid frequent creation and release of the renderer.
- Reduce the number of concurrent processes (to lessen the overhead of process creation and scheduling), and have each process only send the data it needs to process (to reduce data transfer).
- Use BMP as the temporary image storage format and parallelize the rendering and file-saving processes.
- Employ ffmpeg for media processing, which improves generation speed.
- Adjust some rendering configuration parameters, such as video resolution and FPS, allowing for trade-offs between generation speed and quality according to needs.

Notes:
- For media processing with ffmpeg, please install it first: **conda install -c conda-forge ffmpeg.**
- By default, BMP is used as the temporary image format. Generating a video of 1920x720 30fps for 62s requires 9G of disk space temporarily, and a 1920x1080 30fps 62s video needs 11G of disk space. These temporary images will be deleted after video generation, which I think is not too big of an issue. If the space requirement is considered too high, you can set args.render_tmp_img_filetype to "png" to generate temporary PNG files instead, though this may increase the time required.
- I have named the final output video as res_2_scott_0_1_1.mp4, whereas the original code used final_clip as 2_scott_0_1_1.mp4, which I believe should not cause any issue.
- **I only have Windows, and it has been tested and passed on Windows. It has not been tested on other platforms.**